### PR TITLE
Avoid calling Gtk.main_quit too often

### DIFF
--- a/lib/shoes/ruby.rb
+++ b/lib/shoes/ruby.rb
@@ -34,7 +34,7 @@ class Object
   end
   
   def exit
-    (Shoes.APPS.length + 1).times{|i| timer(0.01*i){Gtk.main_quit}}
+    Shoes.APPS.length.times {|i| timer(0.01*i){Gtk.main_quit}}
     File.delete Shoes::TMP_PNG_FILE if File.exist? Shoes::TMP_PNG_FILE
   end
 


### PR DESCRIPTION
In the current implementation of `exit`, Gtk.main_quit is called once more than the number of apps. When running sample4, this leads to error messages on exit if the text in the text box was cut and pasted:

> Gtk-CRITICAL **:IA__gtk_main_quit: assertion `main_loops != NULL' failed

The problem seems to usually not appear because the application has already exited before the extra timer is triggered.

This commit solves the problem.
