### PR TITLE
small change to make it more like red shoes... 

### DIFF
--- a/lib/shoes/widget.rb
+++ b/lib/shoes/widget.rb
@@ -1,9 +1,14 @@
 class Shoes
   class Widget
     def self.inherited klass, &blk
-      m = klass.inspect.downcase.split('::').last
+      puts klass.inspect
+      m = klass.to_s[/(^|::)(\w+)$/, 2].
+              gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+              gsub(/([a-z\d])([A-Z])/,'\1_\2').downcase
+      puts m
       Shoes::App.class_eval do
         define_method m do |*args, &blk|
+          puts klass
           klass.class_variable_set :@@__app__, self
           parent = app.cslot
           klass.new(*args, &blk).tap do |s|


### PR DESCRIPTION
updated green shoes widget parser to transfor FooWidgetThiny into foo_widget_thingy like red shoes

ok, so my commit msg has some spelling errors in it, sue me!  i noticed this discrepancy while playing around with the code that was shared in the list box discussion ~2 weeks ago (yes, i _just_ got around to playing with it :P ) anyway, it was giving me all sorts of errors when using green shoes (and i haven't had the chance to get red shoes working yet) so i tracked it down & quickly patched it up!  i'm getting a new error now, but i'll post that in the error tracker (and it has nothing to do with this patch, i was getting the same exact error before when it was turning ListCell && ListManager to listcell and listmanager respectfully).

YAY MOAR SHOES!!! (almost sleep time for me, manual labor tomorrow UGH!!!)
