### PR TITLE
make alert() thread safe.

### DIFF
--- a/lib/shoes/ruby.rb
+++ b/lib/shoes/ruby.rb
@@ -16,8 +16,10 @@ class Object
       msg.to_s
     )
     dialog.title = "Green Shoes says:"
-    dialog.run
-    dialog.destroy
+    dialog.signal_connect "response" do |response|
+      dialog.destroy
+    end
+    dialog.show
   end
 
   def confirm msg

--- a/lib/shoes/ruby.rb
+++ b/lib/shoes/ruby.rb
@@ -7,7 +7,7 @@ end
 
 class Object
   include Types
-  def alert msg
+  def alert msg, options={:block => true}
     dialog = Gtk::MessageDialog.new(
       get_win,
       Gtk::Dialog::MODAL,
@@ -16,10 +16,16 @@ class Object
       msg.to_s
     )
     dialog.title = "Green Shoes says:"
-    dialog.signal_connect "response" do |response|
+    pd options
+    if options[:block]
+      pd 'run'
+      dialog.run
       dialog.destroy
+    else
+      pd 'show'
+      dialog.signal_connect("response"){ dialog.destroy }
+      dialog.show
     end
-    dialog.show
   end
 
   def confirm msg


### PR DESCRIPTION
Gtk::Dialog#run() is not thread safe.

for Example

``` ruby
Shoes.app do
  Thread.start do
     dialog = Gtk::Dialog.new
     dialog.run
  end
end
```

the main window will be freezed.

more info at http://stackoverflow.com/questions/3504739/twisted-gtk-should-i-run-gui-things-in-threads-or-in-the-reactor-thread
