### PR TITLE
bloopsaphone for non Windows users

### DIFF
--- a/lib/ext/bloops.rb
+++ b/lib/ext/bloops.rb
@@ -1,1 +1,6 @@
-require_relative 'bloops/bloops'
+begin
+  require 'bloops'
+rescue LoadError
+  require_relative 'bloops/bloops'
+end
+


### PR DESCRIPTION
Support for using bloopsaphone on non windows systems when the gem is installed.
